### PR TITLE
allow custom middleware in config

### DIFF
--- a/config/laravel-log-reader.php
+++ b/config/laravel-log-reader.php
@@ -4,4 +4,5 @@ return [
     'api_route_path' => 'admin/api/log-reader',
     'view_route_path' => 'admin/log-reader',
     'admin_panel_path' => 'admin',
+    'middleware' => ['web','auth']
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,5 @@
 <?php
-Route::group(['namespace' => 'Haruncpi\LaravelLogReader\Controllers', 'middleware' => ['web','auth']], function () {
+Route::group(['namespace' => 'Haruncpi\LaravelLogReader\Controllers', 'middleware' => config('laravel-log-reader.middleware')], function () {
 
     Route::get(config('laravel-log-reader.view_route_path'), 'LogReaderController@getIndex');
     Route::post(config('laravel-log-reader.view_route_path'), 'LogReaderController@postDelete');


### PR DESCRIPTION
My default auth guard is `api`. I need to be able to assign a `auth:web` middleware so I can use this package. So this PR will give the user flexibility for middlewares.

A little backstory... I also ran into this problem in https://github.com/laravel/horizon (which really similar with this package), the solution was just like what I mentioned above. Luckily Horizon has `middleware` in its config file.

Anw, This is a really nice package!